### PR TITLE
feat(script): restart openclaw after finish patching

### DIFF
--- a/scripts/patch_openclaw.sh
+++ b/scripts/patch_openclaw.sh
@@ -9,3 +9,5 @@ do
    cp -a ${file_to_patch} ${file_to_patch}.bck
    sed -i "s#https://api.search.brave.com/#http://127.0.0.1:8000/#g" ${file_to_patch}
 done
+
+openclaw gateway restart


### PR DESCRIPTION
I added a command to restart the openclaw automatically after users finish patching the openclaw search